### PR TITLE
Add caching to query functions

### DIFF
--- a/src/queries/home-page.ts
+++ b/src/queries/home-page.ts
@@ -43,6 +43,8 @@ export type HomePageData = Awaited<ReturnType<typeof getHomePageData>>;
 export type QuizCard = HomePageData[number]["quizzes"][number];
 
 export async function getQuiz(slug: string) {
+  "use cache";
+  cacheLife("hours");
   return prisma.quiz.findUnique({
     where: { slug },
     include: {
@@ -69,6 +71,8 @@ export type QuizPageType = NonNullable<Awaited<ReturnType<typeof getQuiz>>>;
 export type QuestionType = QuizPageType["questions"][number];
 
 export async function getMoreQuizzes(currentSlug: string) {
+  "use cache";
+  cacheLife("hours");
   return prisma.quiz.findMany({
     where: { slug: { not: currentSlug } },
     take: 6,

--- a/src/queries/horoscope.ts
+++ b/src/queries/horoscope.ts
@@ -2,8 +2,11 @@ import prisma from "@/lib/prisma";
 import { ZodiacSign } from "@/generated/prisma/client";
 import { endOfDay, startOfDay } from "date-fns";
 import { UTCDate } from "@date-fns/utc";
+import { cacheLife } from "next/cache";
 
 export async function getHoroscopeBySignAndDate(zodiacSign: ZodiacSign, date: Date) {
+  "use cache";
+  cacheLife("hours");
   return prisma.horoscope.findUnique({
     where: {
       zodiacSign_date: {
@@ -15,6 +18,8 @@ export async function getHoroscopeBySignAndDate(zodiacSign: ZodiacSign, date: Da
 }
 
 export async function getAllHoroscopesForDate(date: Date) {
+  "use cache";
+  cacheLife("hours");
   return prisma.horoscope.findMany({
     where: {
       date: {

--- a/src/queries/past-events.ts
+++ b/src/queries/past-events.ts
@@ -1,8 +1,10 @@
 import prisma from '@/lib/prisma'
 import { PastEvent, EventCategory } from '@/generated/prisma/client'
+import { cacheLife } from 'next/cache';
 
 export const getPastEventsByMonthDay = async (month: number, day: number): Promise<PastEvent[]> => {
-
+  "use cache";
+  cacheLife("days");
 
   try {
     const events = await prisma.pastEvent.findMany({
@@ -42,7 +44,8 @@ export const getPastEventsByMonthDay = async (month: number, day: number): Promi
 }
 
 export const getPastEventsByCategory = async (category: EventCategory): Promise<PastEvent[]> => {
-
+  "use cache";
+  cacheLife("days");
 
   try {
     const events = await prisma.pastEvent.findMany({
@@ -82,6 +85,9 @@ export const getPastEventsByCategory = async (category: EventCategory): Promise<
 }
 
 export const getAllEventCategories = async (): Promise<EventCategory[]> => {
+  "use cache";
+  cacheLife("days");
+
   try {
     const events = await prisma.pastEvent.findMany({
       where: {

--- a/src/queries/stats.ts
+++ b/src/queries/stats.ts
@@ -1,6 +1,10 @@
 import prisma from "@/lib/prisma";
+import { cacheLife } from "next/cache";
 
 export async function getStats() {
+  "use cache";
+  cacheLife("hours");
+
   const [totalQuizzes, totalCategories, totalSubCategories] = await Promise.all([
     prisma.quiz.count(),
     prisma.category.count(),


### PR DESCRIPTION
Introduce caching directives to various data‑fetching utilities, setting appropriate cache lifetimes (hours for quizzes and stats, days for events and horoscope). This reduces database load and improves response times for common queries.