### PR TITLE
Move progress UI from QuestionCard to question list

### DIFF
--- a/src/components/quiz-page/question-list.tsx
+++ b/src/components/quiz-page/question-list.tsx
@@ -104,17 +104,67 @@ export default function QuizQuestions({ questions }: { questions: QuestionType[]
               index={i}
               selected={answers[i]}
               onAnswer={setAnswer}
-              isLastQuestion={i === totalQuestions - 1}
               totalQuestions={totalQuestions}
-              progress={progress}
-              isComplete={isComplete}
-              correct={correct}
-              percentage={percentage}
-              reset={reset}
             />
           </li>
         ))}
       </ol>
+
+      {/* Progress bar after last question - transforms to results when complete */}
+      <div className="max-w-4xl mx-auto pl-4 sm:pl-7 pr-4 sm:pr-6 mt-5 sm:mt-6">
+        {isComplete ? (
+          // Results display when complete
+          <div className="rounded-2xl border border-white/10 bg-white/50 dark:bg-slate-950/50 backdrop-blur-xl shadow-[0_8px_30px_rgb(0,0,0,0.04)] dark:shadow-[0_8px_30px_rgb(0,0,0,0.1)] p-5 sm:p-6 space-y-4">
+            <div className="text-center">
+              <Trophy className="w-8 h-8 text-green-500 mx-auto mb-2" />
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">Quiz Complete!</h3>
+              <p className={cn("text-sm font-medium", getQuizScoreColor(percentage))}>
+                {getQuizScoreMessage(percentage)}
+              </p>
+            </div>
+
+            <div className="grid grid-cols-3 gap-3 text-center">
+              <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-3 border border-green-200 dark:border-green-700/30">
+                <div className="text-2xl font-bold text-green-700 dark:text-green-300">{correct}</div>
+                <div className="text-xs text-green-600 dark:text-green-400">Correct</div>
+              </div>
+              <div className="bg-red-50 dark:bg-red-900/20 rounded-lg p-3 border border-red-200 dark:border-red-700/30">
+                <div className="text-2xl font-bold text-red-700 dark:text-red-300">{totalQuestions - correct}</div>
+                <div className="text-xs text-red-600 dark:text-red-400">Incorrect</div>
+              </div>
+              <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3 border border-gray-200 dark:border-gray-700">
+                <div className="text-2xl font-bold text-gray-900 dark:text-white">{percentage}%</div>
+                <div className="text-xs text-gray-600 dark:text-gray-400">Score</div>
+              </div>
+            </div>
+
+            <button
+              onClick={() => reset()}
+              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-violet-600 hover:bg-violet-700 text-white font-medium rounded-lg transition-colors"
+            >
+              <RotateCcw className="w-4 h-4" />
+              Try Again
+            </button>
+          </div>
+        ) : (
+          // Progress bar when in progress
+          <div className="rounded-2xl border border-white/10 bg-white/50 dark:bg-slate-950/50 backdrop-blur-xl shadow-[0_8px_30px_rgb(0,0,0,0.04)] dark:shadow-[0_8px_30px_rgb(0,0,0,0.1)] p-5 sm:p-6">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <Trophy className="w-5 h-5 text-violet-500" />
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Your Progress</span>
+              </div>
+              <span className="text-2xl font-bold text-gray-900 dark:text-white">{progress}%</span>
+            </div>
+            <div className="relative w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+              <div
+                className="h-full rounded-full transition-all duration-500 ease-out bg-linear-to-r from-violet-500 to-fuchsia-500"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -124,25 +174,13 @@ function QuestionCard({
   index,
   selected,
   onAnswer,
-  isLastQuestion,
-  totalQuestions,
-  progress,
-  isComplete,
-  correct,
-  percentage,
-  reset
+  totalQuestions
 }: {
   q: QuestionType;
   index: number;
   selected?: number;
   onAnswer?: (questionIndex: number, answerIndex: number) => void;
-  isLastQuestion: boolean;
   totalQuestions: number;
-  progress: number;
-  isComplete: boolean;
-  correct: number;
-  percentage: number;
-  reset: () => void;
 }) {
   const isAnswered = selected !== undefined && selected !== null;
   const isDisabled = isAnswered;
@@ -180,64 +218,6 @@ function QuestionCard({
             <Info className="w-4 h-4 mt-0.5 text-blue-500 dark:text-blue-400 shrink-0" />
             <span>{q.explanation}</span>
           </div>
-        </div>
-      )}
-
-      {/* Progress bar after last question - transforms to results when complete */}
-      {isLastQuestion && (
-        <div className="mt-6 pt-5 sm:pt-6 border-t border-gray-200 dark:border-white/10">
-          {isComplete ? (
-            // Results display when complete
-            <div className="space-y-4">
-              <div className="text-center">
-                <Trophy className="w-8 h-8 text-green-500 mx-auto mb-2" />
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">Quiz Complete!</h3>
-                <p className={cn("text-sm font-medium", getQuizScoreColor(percentage))}>
-                  {getQuizScoreMessage(percentage)}
-                </p>
-              </div>
-
-              <div className="grid grid-cols-3 gap-3 text-center">
-                <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-3 border border-green-200 dark:border-green-700/30">
-                  <div className="text-2xl font-bold text-green-700 dark:text-green-300">{correct}</div>
-                  <div className="text-xs text-green-600 dark:text-green-400">Correct</div>
-                </div>
-                <div className="bg-red-50 dark:bg-red-900/20 rounded-lg p-3 border border-red-200 dark:border-red-700/30">
-                  <div className="text-2xl font-bold text-red-700 dark:text-red-300">{totalQuestions - correct}</div>
-                  <div className="text-xs text-red-600 dark:text-red-400">Incorrect</div>
-                </div>
-                <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3 border border-gray-200 dark:border-gray-700">
-                  <div className="text-2xl font-bold text-gray-900 dark:text-white">{percentage}%</div>
-                  <div className="text-xs text-gray-600 dark:text-gray-400">Score</div>
-                </div>
-              </div>
-
-              <button
-                onClick={() => reset()}
-                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-violet-600 hover:bg-violet-700 text-white font-medium rounded-lg transition-colors"
-              >
-                <RotateCcw className="w-4 h-4" />
-                Try Again
-              </button>
-            </div>
-          ) : (
-            // Progress bar when in progress
-            <div>
-              <div className="flex items-center justify-between mb-3">
-                <div className="flex items-center gap-2">
-                  <Trophy className="w-5 h-5 text-violet-500" />
-                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Your Progress</span>
-                </div>
-                <span className="text-2xl font-bold text-gray-900 dark:text-white">{progress}%</span>
-              </div>
-              <div className="relative w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
-                <div
-                  className="h-full rounded-full transition-all duration-500 ease-out bg-linear-to-r from-violet-500 to-fuchsia-500"
-                  style={{ width: `${progress}%` }}
-                />
-              </div>
-            </div>
-          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Centralizes the quiz progress bar and result summary, moving them from each QuestionCard into a single section after the question list. Removes the now‑unnecessary props (`isLastQuestion`, `progress`, `isComplete`, `correct`, `percentage`, `reset`) from QuestionCard, simplifying its interface and avoiding duplicated UI logic.